### PR TITLE
Mark as DevelopmentDependency

### DIFF
--- a/src/PowerBridge/PowerBridge.nuspec
+++ b/src/PowerBridge/PowerBridge.nuspec
@@ -13,6 +13,7 @@
     <description>$description$</description>
     <copyright>$copyright$</copyright>
     <tags>powershell msbuild build task</tags>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="NugetPackageFiles\tools\install.ps1" target="tools"/>


### PR DESCRIPTION
https://docs.nuget.org/release-notes/nuget-2.8

Development Dependencies
Many different types of capabilities can be delivered as NuGet packages - including tools that are used for optimizing the development process. These components, while they can be instrumental in developing a new package, should not be considered a dependency of the new package when it is later published. NuGet 2.8 enables a package to identify itself in the .nuspec file as a developmentDependency. When installed, this metadata will also be added to the packages.config file of the project into which the package was installed. **When that packages.config file is later analyzed for NuGet dependencies during nuget.exe pack, it will exclude those dependences marked as development dependencies.**
